### PR TITLE
Fix syntax highlighting errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install quantize-colors
 
 ## Usage
 
-```bash
+```js
 const quantizeColors = require('quantize-colors');
 
 // Example: Get the quantized colors of an image


### PR DESCRIPTION
The JavaScript example code in the README is improperly specified as Bash code, causing the colors to be incorrect. This just fixes that by changing it from `bash` to `js`.